### PR TITLE
Added Auto Resolving of java package names

### DIFF
--- a/src/main/java/org/expretio/maven/plugins/capnp/CapnProtoMojo.java
+++ b/src/main/java/org/expretio/maven/plugins/capnp/CapnProtoMojo.java
@@ -171,6 +171,13 @@ public class CapnProtoMojo
     @Parameter( defaultValue = "true", required = true )
     private boolean handleNativeDependency;
 
+    /**
+     * Tries to resolve the package name given by '$Java.package("...");' in
+     * the schema file and creates the source file in the corresponding directory
+     */
+    @Parameter( defaultValue = "false", required = true )
+    private boolean resolvePackageName;
+    
     private final NativesManager nativesManager = new NativesManager();
 
     @Override

--- a/src/main/java/org/expretio/maven/plugins/capnp/CapnpCompiler.java
+++ b/src/main/java/org/expretio/maven/plugins/capnp/CapnpCompiler.java
@@ -24,23 +24,28 @@ package org.expretio.maven.plugins.capnp;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+
+import com.google.common.io.Files;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.FileUtils;
+import org.expretio.maven.plugins.capnp.util.SchemaExtendedInfo;
 
 /**
- * Implements a java adapter of capnproto compiler, creating java classes from schema definitions.
+ * Implements a java adapter of capnproto compiler, creating java classes from
+ * schema definitions.
  *
  * @see #builder()
  */
-public class CapnpCompiler
-{
-    public static Builder builder()
-    {
+public class CapnpCompiler {
+    public static Builder builder() {
         return new Builder();
     }
 
@@ -51,35 +56,25 @@ public class CapnpCompiler
     /**
      * Constructor.
      */
-    private CapnpCompiler( Command command, List<String> schemas, boolean verbose )
-    {
+    private CapnpCompiler(Command command, List<String> schemas, boolean verbose) {
         this.command = command;
         this.schemas = schemas;
         this.verbose = verbose;
     }
 
-    public void compile()
-        throws MojoExecutionException
-    {
-        for ( String schema : schemas )
-        {
-            compile( schema );
+    public void compile() throws MojoExecutionException {
+        for (String schema : schemas) {
+            compile(schema);
         }
     }
 
     // [ Utility methods ]
 
-    private void compile( String schema )
-        throws MojoExecutionException
-    {
-        try
-        {
-            ProcessBuilder processBuilder =
-                    new ProcessBuilder( command.get( schema ) )
-                        .directory( command.workDirectory );
+    private void compile(String schema) throws MojoExecutionException {
+        try {
+            ProcessBuilder processBuilder = new ProcessBuilder(command.get(schema)).directory(command.workDirectory);
 
-            if ( verbose )
-            {
+            if (verbose) {
                 processBuilder.inheritIO();
             }
 
@@ -87,21 +82,17 @@ public class CapnpCompiler
 
             int exit = process.waitFor();
 
-            if ( exit != 0 )
-            {
-                throw new MojoExecutionException( "Unexpected exit value ( " + exit + " ) while compiling " + schema );
+            if (exit != 0) {
+                throw new MojoExecutionException("Unexpected exit value ( " + exit + " ) while compiling " + schema);
             }
-        }
-        catch ( IOException | InterruptedException e )
-        {
-            throw new MojoExecutionException( "Cannot compile schema " + schema + ".", e );
+        } catch (IOException | InterruptedException e) {
+            throw new MojoExecutionException("Cannot compile schema " + schema + ".", e);
         }
     }
 
     // [ Inner classes ]
 
-    private static class Command
-    {
+    private static class Command {
         private final File outputDirectory;
         private final File schemaDirectory;
         private final File workDirectory;
@@ -109,19 +100,13 @@ public class CapnpCompiler
         private final File capnpcJavaFile;
         private final File capnpJavaSchemaFile;
         private List<File> importDirectories;
+        private final boolean mapPackagesToDirectories;
 
         private List<String> base = new ArrayList<>();
 
-        public Command(
-                File outputDirectory,
-                File schemaDirectory,
-                File workDirectory,
-                File capnpFile,
-                File capnpcJavaFile,
-                File capnpJavaSchemaFile,
-                List<File> importDirectories )
-            throws MojoExecutionException, MojoFailureException
-        {
+        public Command(File outputDirectory, File schemaDirectory, File workDirectory, File capnpFile,
+                File capnpcJavaFile, File capnpJavaSchemaFile, List<File> importDirectories,
+                boolean mapPackagesToDirectories) throws MojoExecutionException, MojoFailureException {
             this.outputDirectory = outputDirectory;
             this.schemaDirectory = schemaDirectory;
             this.workDirectory = workDirectory;
@@ -129,56 +114,69 @@ public class CapnpCompiler
             this.capnpcJavaFile = capnpcJavaFile;
             this.capnpJavaSchemaFile = capnpJavaSchemaFile;
             this.importDirectories = importDirectories;
+            this.mapPackagesToDirectories = mapPackagesToDirectories;
 
             initialize();
         }
 
-        public List<String> get( String schema )
-        {
-            List<String> fullCommand = new ArrayList<>( base );
-            fullCommand.add( schema );
+        public List<String> get(String schema) {
+            List<String> fullCommand = new ArrayList<>(base);
+
+            if (this.mapPackagesToDirectories == true) {
+                File schemaFile = Paths.get(this.workDirectory.getAbsolutePath(), schema).toFile();
+                Optional<String> packageName = SchemaExtendedInfo.getPackageName(schemaFile);
+                if (packageName.isPresent()) {
+                    String packageDir = SchemaExtendedInfo.packageNameToDirectory(packageName.get());
+                    File packageMappedDir = Paths.get(this.workDirectory.getAbsolutePath(), packageDir).toFile();
+                    packageMappedDir.mkdirs();
+                    File packageMappedFile = Paths.get(packageMappedDir.getAbsolutePath(), new File(schema).getName())
+                            .toFile();
+                    try {
+                        Files.move(schemaFile, packageMappedFile);
+                        fullCommand
+                                .add(Paths.get(packageDir, packageMappedFile.getName()).toString().replace("\\", "/"));
+                        return fullCommand;
+                    } catch (IOException e) {
+                        // silently ignore and skip packagename resolving
+                    }
+                }
+            }
+
+            fullCommand.add(schema);
 
             return fullCommand;
         }
 
-        private void initialize()
-            throws MojoExecutionException
-        {
+        private void initialize() throws MojoExecutionException {
             outputDirectory.mkdirs();
             workDirectory.mkdirs();
 
-            try
-            {
-                FileUtils.copyDirectoryStructure( schemaDirectory, workDirectory );
+            try {
+                FileUtils.copyDirectoryStructure(schemaDirectory, workDirectory);
 
-                importDirectories.add( capnpJavaSchemaFile.getParentFile() );
-                importDirectories.add( schemaDirectory );
+                importDirectories.add(capnpJavaSchemaFile.getParentFile());
+                importDirectories.add(schemaDirectory);
 
                 setBase();
-            }
-            catch ( IOException e )
-            {
-                throw new MojoExecutionException( "Unable to initialize capnp environment.", e );
+            } catch (IOException e) {
+                throw new MojoExecutionException("Unable to initialize capnp environment.", e);
             }
         }
 
-        private void setBase()
-            throws IOException
-        {
-            base.add( capnpFile.getAbsolutePath() );
-            base.add( "compile" );
-            base.add( "--verbose" );
-            base.add( "-o" + capnpcJavaFile.getAbsolutePath() + ":" + outputDirectory.getAbsolutePath() );
+        private void setBase() throws IOException {
+            base.add(capnpFile.getAbsolutePath());
+            base.add("compile");
+            base.add("--verbose");
 
-            for ( File importDirectory : importDirectories )
-            {
-                base.add( "-I" + importDirectory.getAbsolutePath() );
+            base.add("-o" + capnpcJavaFile.getAbsolutePath() + ":" + outputDirectory.getAbsolutePath());
+
+            for (File importDirectory : importDirectories) {
+                base.add("-I" + importDirectory.getAbsolutePath());
             }
         }
     }
 
-    public static class Builder
-    {
+    public static class Builder {
         private File outputDirectory;
         private File schemaDirectory;
         private File workDirectory;
@@ -188,132 +186,111 @@ public class CapnpCompiler
         private final List<File> importDirectories = new ArrayList<>();
         private final List<String> schemas = new ArrayList<>();
         private boolean verbose = true;
+        private boolean mapPackagesToDirectories = true;
 
-        public CapnpCompiler build()
-            throws MojoExecutionException, MojoFailureException
-        {
+        public CapnpCompiler build() throws MojoExecutionException, MojoFailureException {
             validate();
 
-            Command command =
-                new Command(
-                        outputDirectory,
-                        schemaDirectory,
-                        workDirectory,
-                        capnpFile,
-                        capnpcJavaFile,
-                        capnpJavaSchemaFile,
-                        importDirectories );
+            Command command = new Command(outputDirectory, schemaDirectory, workDirectory, capnpFile, capnpcJavaFile,
+                    capnpJavaSchemaFile, importDirectories, mapPackagesToDirectories);
 
-            return new CapnpCompiler( command, schemas, verbose );
+            return new CapnpCompiler(command, schemas, verbose);
         }
 
-        public Builder setOutputDirectory( File outputDirectory )
-        {
+        public Builder setOutputDirectory(File outputDirectory) {
             this.outputDirectory = outputDirectory;
 
             return this;
         }
 
-        public Builder setSchemaDirectory( File schemaDirectory )
-        {
+        public Builder setSchemaDirectory(File schemaDirectory) {
             this.schemaDirectory = schemaDirectory;
 
             return this;
         }
 
-        public Builder setWorkDirectory( File workDirectory )
-        {
+        public Builder setWorkDirectory(File workDirectory) {
             this.workDirectory = workDirectory;
 
             return this;
         }
 
-        public Builder setCapnpFile( File capnpFile )
-        {
+        public Builder setCapnpFile(File capnpFile) {
             this.capnpFile = capnpFile;
 
             return this;
         }
 
-        public Builder setCapnpcJavaFile( File capnpcJavaFile )
-        {
+        public Builder setCapnpcJavaFile(File capnpcJavaFile) {
             this.capnpcJavaFile = capnpcJavaFile;
 
             return this;
         }
 
-        public Builder setCapnpJavaSchemaFile( File capnpJavaSchemaFile )
-        {
+        public Builder setCapnpJavaSchemaFile(File capnpJavaSchemaFile) {
             this.capnpJavaSchemaFile = capnpJavaSchemaFile;
 
             return this;
         }
 
-        public Builder addImportDirectory( File importDirectory )
-        {
-            importDirectories.add( importDirectory );
+        public Builder addImportDirectory(File importDirectory) {
+            importDirectories.add(importDirectory);
 
             return this;
         }
 
-        public Builder addImportDirectories( Collection<File> importDirectories )
-        {
-            this.importDirectories.addAll( importDirectories );
+        public Builder addImportDirectories(Collection<File> importDirectories) {
+            this.importDirectories.addAll(importDirectories);
 
             return this;
         }
 
-        public Builder addSchema( String schema )
-        {
-            schemas.add( schema );
+        public Builder addSchema(String schema) {
+            schemas.add(schema);
 
             return this;
         }
 
-        public Builder addSchemas( Collection<String> schemas )
-        {
-            this.schemas.addAll( schemas );
+        public Builder addSchemas(Collection<String> schemas) {
+            this.schemas.addAll(schemas);
 
             return this;
         }
 
-        public Builder setVerbose( boolean value )
-        {
+        public Builder setVerbose(boolean value) {
             this.verbose = value;
 
             return this;
         }
 
-        private void validate()
-            throws MojoFailureException
-        {
-            validate( outputDirectory, "Output directory" );
-            validate( schemaDirectory, "Schema base directory" );
-            validate( workDirectory, "Working directory" );
+        public Builder setMapPackagesToDirectories(boolean value) {
+            this.mapPackagesToDirectories = value;
 
-            validate( capnpFile, "capnpn file" );
-            validate( capnpcJavaFile, "capnpnc java file" );
-            validate( capnpJavaSchemaFile, "capnpn java schema file" );
+            return this;
+        }
 
-            for ( File importDirectory : importDirectories )
-            {
-                validate( importDirectory, "Import directory" );
+        private void validate() throws MojoFailureException {
+            validate(outputDirectory, "Output directory");
+            validate(schemaDirectory, "Schema base directory");
+            validate(workDirectory, "Working directory");
+
+            validate(capnpFile, "capnpn file");
+            validate(capnpcJavaFile, "capnpnc java file");
+            validate(capnpJavaSchemaFile, "capnpn java schema file");
+
+            for (File importDirectory : importDirectories) {
+                validate(importDirectory, "Import directory");
             }
 
-            if ( schemas.isEmpty() )
-            {
-                throw new MojoFailureException( "At least one schema file must be specified." );
+            if (schemas.isEmpty()) {
+                throw new MojoFailureException("At least one schema file must be specified.");
             }
         }
 
-        private void validate( File file, String name )
-            throws MojoFailureException
-        {
-            if ( file == null )
-            {
-                throw new MojoFailureException( name + " is mandatory." );
+        private void validate(File file, String name) throws MojoFailureException {
+            if (file == null) {
+                throw new MojoFailureException(name + " is mandatory.");
             }
         }
     }
 }
-

--- a/src/main/java/org/expretio/maven/plugins/capnp/util/SchemaExtendedInfo.java
+++ b/src/main/java/org/expretio/maven/plugins/capnp/util/SchemaExtendedInfo.java
@@ -1,0 +1,37 @@
+package org.expretio.maven.plugins.capnp.util;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SchemaExtendedInfo {
+
+    private static final Pattern packageDirectiveMatcher = Pattern
+            .compile("^\\$Java.package\\(\"([a-z][a-z0-9_]*(\\.[a-z0-9_]+)+[0-9a-z_])\"\\);$");
+
+    public static Optional<String> getPackageName(File schemaFile) {
+        try (BufferedReader reader = new BufferedReader(new FileReader(schemaFile))) {
+            String line = reader.readLine();
+            while (line != null) {
+                Matcher matcher = packageDirectiveMatcher.matcher(line);
+                if (matcher.matches()) {
+                    return Optional.of(matcher.group(1));
+                }
+                line = reader.readLine();
+            }
+        } catch (IOException e) {
+            // throw new IOException(String.format("Failed to read Schemafile for PackageName resolution. \"%s\"",
+            //         schemaFile.getAbsolutePath()), e);
+            return Optional.empty();
+        }
+        return Optional.empty();
+    }
+
+    public static String packageNameToDirectory(String packageName) {
+        return String.join("/", packageName.split("\\."));
+    }
+}

--- a/src/test/java/org/expretio/maven/plugins/capnp/util/SchemaExtendedInfoTest.java
+++ b/src/test/java/org/expretio/maven/plugins/capnp/util/SchemaExtendedInfoTest.java
@@ -1,0 +1,56 @@
+package org.expretio.maven.plugins.capnp.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.junit.Test;
+
+public class SchemaExtendedInfoTest {
+
+    @Test
+    public void findsCorrectPackageInAlpha() throws IOException {
+
+        Optional<String> packageName = SchemaExtendedInfo.getPackageName(getAlpha());
+        assertTrue(packageName.isPresent());
+        assertEquals("org.expretio.maven.plugins.capnp.alpha", packageName.get());
+    }
+
+    @Test
+    public void findsCorrectPackageInBeta() throws IOException {
+
+        Optional<String> packageName = SchemaExtendedInfo.getPackageName(getBeta());
+        assertTrue(packageName.isPresent());
+        assertEquals("org.expretio.maven.plugins.capnp.beta", packageName.get());
+    }
+
+    private File getAlpha() {
+        try {
+            return Paths.get(this.getClass().getClassLoader()
+                    .getResource("org/expretio/maven/plugins/capnp/alpha/alpha.capnp").toURI()).toFile();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void mapsPackageNameToDirectory() {
+        assertEquals("org/expretio/maven/plugins/capnp/beta",
+                SchemaExtendedInfo.packageNameToDirectory("org.expretio.maven.plugins.capnp.beta"));
+    }
+
+    private File getBeta() {
+        try {
+            return Paths.get(this.getClass().getClassLoader()
+                    .getResource("org/expretio/maven/plugins/capnp/beta/beta.capnp").toURI()).toFile();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
Hey, as I had the same problem as in https://github.com/expretio/capnp-maven-plugin/issues/2 I created a parameter for the plugin
"resolvePackageName"
This way it automatically generates the source files in the "correct" (for Java Language Server classpath resolution) subdirectory of "generated-sources/capnp".
Currently it simply scans the schema files for $Java.package(...).

For me it doesn't make sense to put the capnp file in the correct "java" directory as it is also used in a python context where directories are named differently.

This can definitely be perfected, but I wanted to see whether there is any motivation in adding such a feature first.

Also I can clean up the formatting... Most of the changes come from that.

Tell me what you think